### PR TITLE
Change MarshalJSON to omit some attributes

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,65 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat/go-jsschema"
+	"github.com/lestrrat/go-jsschema/validator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	// roundTripSchemas are schemas that can be read and written back to the same
+	// content. They also include an object that should match the schema to make
+	// sure the schema is correctly written.
+	var roundTripSchemas = []struct {
+		Name       string
+		Schema     string
+		ValidValue interface{}
+	}{{
+		Name: "Integer",
+		Schema: `{
+  "type": "integer"
+}`,
+		ValidValue: int(0),
+	}, {
+		Name: "String",
+		Schema: `{
+  "type": "string"
+}`,
+		ValidValue: "value",
+	}, {
+		Name: "Object",
+		Schema: `{
+  "additionalProperties": false,
+  "properties": {
+    "attr": {
+      "type": "integer"
+    }
+  },
+  "type": "object"
+}`,
+		ValidValue: struct{ attr int }{10},
+	}}
+	for _, definition := range roundTripSchemas {
+		t.Logf("Testing schema %s", definition.Name)
+		s, err := schema.Read(strings.NewReader(definition.Schema))
+		if !assert.NoError(t, err, "schema.Read should succeed") {
+			return
+		}
+		v := validator.New(s)
+		err = v.Validate(definition.ValidValue)
+		if !assert.NoError(t, err, "ValidValue should Validate successfully") {
+			return
+		}
+		output, err := json.MarshalIndent(s, "", "  ")
+		if !assert.NoError(t, err, "json.Marshal should succeed") {
+			return
+		}
+		if !assert.Equal(t, definition.Schema, string(output), "json.Marshal should result in the same value as the input.") {
+			return
+		}
+	}
+}


### PR DESCRIPTION
Before this patch, all objects ended up with an additionalItems: false and additionalProperties: false attributes. However, from what I can tell on other specs, those attributes are only interesting if you are dealing with an array or object, respectively.

This allows us to create a Schema object and then MarshalJSON it back to a JSON format and have it still look nice.
