### PR TITLE
Conversion cleanup

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,15 +1,7 @@
 package schema
 
-import (
-	"reflect"
-
-	"github.com/pkg/errors"
-)
+import "github.com/pkg/errors"
 
 func errInvalidType(s string, v interface{}) error {
-	return errors.Errorf(
-		"invalid type: expected %s, got %s",
-		s,
-		reflect.TypeOf(v).String(),
-	)
+	return errors.Errorf("invalid type: expected %s, got %T", s, v)
 }


### PR DESCRIPTION
This change cleans up some of the type conversions - many were using a switch where
the v, ok style would work just as well.  Also use the type switch assignment
to avoid converting twice in the switches.  Finally, use %T in the error message
rather than using reflect directly.