### PR TITLE
wrong variable is used?

### DIFF
--- a/primitives.go
+++ b/primitives.go
@@ -12,7 +12,7 @@ func (t *PrimitiveType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-	x, err := primitiveFromString(string(data))
+	x, err := primitiveFromString(s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
raw data is used when calling primitiveFromString() in PrimitiveType.UnmarshalJSON() in spite of there's unmarshaled data(unmashaled s is not used)